### PR TITLE
Minor fixes for wrong stats/typos

### DIFF
--- a/1.6/Defs/ThingDef/Apparel_Headgear.xml
+++ b/1.6/Defs/ThingDef/Apparel_Headgear.xml
@@ -4,7 +4,6 @@
     <equippedStatOffsets>
       <DecompressionResistance MayRequire="kentington.saveourship2">0.25</DecompressionResistance>
       <HypoxiaResistance MayRequire="kentington.saveourship2">1</HypoxiaResistance>
-      <DecompressionResistance MayRequire="kentington.saveourship2">0.75</DecompressionResistance>
     </equippedStatOffsets>
     <recipeMaker>
       <skillRequirements>
@@ -286,8 +285,8 @@
       <ArmorRating_Sharp>0.88</ArmorRating_Sharp>
       <ArmorRating_Blunt>0.25</ArmorRating_Blunt>
       <ArmorRating_Heat>0.9</ArmorRating_Heat>
-      <Insulation_Cold>0.44</Insulation_Cold>
-      <Insulation_Heat>0.36</Insulation_Heat>
+      <Insulation_Cold>44</Insulation_Cold>
+      <Insulation_Heat>36</Insulation_Heat>
       <EquipDelay>6</EquipDelay>
       <WorkToMake>2200</WorkToMake>
     </statBases>
@@ -406,8 +405,8 @@
       <ArmorRating_Sharp>1.10</ArmorRating_Sharp>
       <ArmorRating_Blunt>0.38</ArmorRating_Blunt>
       <ArmorRating_Heat>1</ArmorRating_Heat>
-      <Insulation_Cold>0.34</Insulation_Cold>
-      <Insulation_Heat>0.1</Insulation_Heat>
+      <Insulation_Cold>34</Insulation_Cold>
+      <Insulation_Heat>10</Insulation_Heat>
       <EquipDelay>6</EquipDelay>
       <WorkToMake>2200</WorkToMake>
     </statBases>
@@ -524,8 +523,8 @@
       <ArmorRating_Sharp>1.00</ArmorRating_Sharp>
       <ArmorRating_Blunt>0.36</ArmorRating_Blunt>
       <ArmorRating_Heat>0.8</ArmorRating_Heat>
-      <Insulation_Cold>0.34</Insulation_Cold>
-      <Insulation_Heat>0.1</Insulation_Heat>
+      <Insulation_Cold>34</Insulation_Cold>
+      <Insulation_Heat>10</Insulation_Heat>
       <EquipDelay>6</EquipDelay>
       <WorkToMake>2200</WorkToMake>
     </statBases>


### PR DESCRIPTION
The helmet base contained a duped SOS2 stat causing helmets to have incorrect decompression resistance after Def inheritance.

Three helmets used wrong values (incorrect decimals) for temperature insulation. (0.34 instead of 34, etc.)

There's still some issues mostly with the body armors and incoherent use of the different shield Comps (vanilla vs. VE) and it seems some recharge rates are off because of that, but that will need some more looking into to find the best fixes for them, so that will be something for the future.

People also reported issues with 'carry capacity' statOffsets not being applied - can't confirm, but it seems like the body armors that do are using the (rather meaningless) vanilla carry capacity. Might be a good idea to given them (conditionally with VEF) the VE stat for mass carry capacity as well, so their buff affects the actual pawn inventory & caravan carry capacity. Might have to be checked against some other mods dealing with similar things - like CE - first though, to not cause unnecessary issues.